### PR TITLE
Fix stats merge to preserve daily history

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -210,12 +210,11 @@ export function getStoredConfig(): AppConfig {
         },
         stats: {
           ...defaultConfig.stats,
-          ...config.stats
-        },
-        stats: {
-          ...defaultConfig.stats,
           ...config.stats,
-          dailyHistory: config.stats?.dailyHistory || []
+          dailyHistory: [
+            ...(defaultConfig.stats?.dailyHistory || []),
+            ...(config.stats?.dailyHistory || [])
+          ]
         }
       };
       


### PR DESCRIPTION
## Summary
- Avoid duplicate `stats` property when merging stored config
- Merge `dailyHistory` entries with defaults to preserve existing stats

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 33 errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bab994bc38832988d7500483383237