### PR TITLE
refactor: apply theme palette and remove inline styles

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -203,7 +203,7 @@ function App() {
   }
 
   return (
-    <div className="min-h-screen" style={{ backgroundColor: activeTheme?.backgroundColor }}>
+    <div className="min-h-screen bg-background text-text">
       {/* Header */}
       <header className="bg-white shadow-sm border-b sticky top-0 z-40">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/src/components/Admin/GainsManagement.tsx
+++ b/src/components/Admin/GainsManagement.tsx
@@ -78,7 +78,7 @@ export function GainsManagement({ prizes, onUpdatePrizes }: GainsManagementProps
           </button>
           <button
             onClick={handleAddPrize}
-            className="bg-green-500 text-white px-4 py-2 rounded hover:bg-green-600 transition-colors"
+            className="btn-primary"
           >
             Ajouter un prix
           </button>
@@ -96,12 +96,12 @@ export function GainsManagement({ prizes, onUpdatePrizes }: GainsManagementProps
 
       <div className="grid gap-4">
         {prizes.map((prize) => (
-          <div key={prize.id} className="bg-white border border-gray-200 rounded-lg p-4">
+          <div key={prize.id} className="bg-white dark:bg-gray-800 border border-gray-200 rounded-lg p-4">
             <div className="flex items-center justify-between">
               <div className="flex items-center space-x-3">
-                <div 
-                  className="w-12 h-12 rounded-full flex items-center justify-center text-2xl"
-                  style={{ backgroundColor: prize.color }}
+                <div
+                  style={{ '--prize-color': prize.color }}
+                  className="w-12 h-12 rounded-full flex items-center justify-center text-2xl bg-[var(--prize-color)]"
                 >
                   {prize.icon}
                 </div>
@@ -151,7 +151,7 @@ export function GainsManagement({ prizes, onUpdatePrizes }: GainsManagementProps
 
       {editingPrize && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
-          <div className="bg-white rounded-lg p-6 w-full max-w-md">
+          <div className="bg-white dark:bg-gray-800 rounded-lg p-6 w-full max-w-md">
             <h4 className="text-lg font-semibold mb-4">Modifier le prix</h4>
             
             <div className="space-y-4">

--- a/src/components/Admin/Settings.tsx
+++ b/src/components/Admin/Settings.tsx
@@ -228,7 +228,7 @@ export function Settings({ gameSettings, texts, onUpdateSettings, onUpdateTexts 
     <div className="space-y-6">
       <h3 className="text-xl font-bold">Paramètres</h3>
 
-      <div className="bg-white p-6 rounded-lg shadow border space-y-6">
+      <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow border space-y-6">
         <h4 className="text-lg font-semibold">Limites de jeu</h4>
         
         <div className="space-y-4">
@@ -273,7 +273,7 @@ export function Settings({ gameSettings, texts, onUpdateSettings, onUpdateTexts 
         </div>
       </div>
 
-      <div className="bg-white p-6 rounded-lg shadow border space-y-4">
+      <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow border space-y-4">
         <h4 className="text-lg font-semibold">Configuration Google</h4>
         
         <div>
@@ -293,7 +293,7 @@ export function Settings({ gameSettings, texts, onUpdateSettings, onUpdateTexts 
         </div>
       </div>
 
-      <div className="bg-white p-6 rounded-lg shadow border">
+      <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow border">
         <div className="flex justify-between items-center mb-4">
           <h4 className="text-lg font-semibold">Mentions légales</h4>
           <button
@@ -312,7 +312,7 @@ export function Settings({ gameSettings, texts, onUpdateSettings, onUpdateTexts 
         </div>
       </div>
 
-      <div className="bg-white p-6 rounded-lg shadow border">
+      <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow border">
         <div className="flex justify-between items-center mb-4">
           <h4 className="text-lg font-semibold">Règles du jeu</h4>
           <button
@@ -331,12 +331,12 @@ export function Settings({ gameSettings, texts, onUpdateSettings, onUpdateTexts 
         </div>
       </div>
 
-      <div className="bg-white p-6 rounded-lg shadow border">
+      <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow border">
         <div className="flex justify-between items-center mb-4">
           <h4 className="text-lg font-semibold">Boutons d'actions généraux</h4>
           <button
             onClick={() => setEditingButtons(true)}
-            className="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600 transition-colors"
+            className="btn-primary"
           >
             Gérer les boutons généraux
           </button>
@@ -347,11 +347,8 @@ export function Settings({ gameSettings, texts, onUpdateSettings, onUpdateTexts 
             <div key={button.id} className="flex items-center justify-between p-3 bg-gray-50 rounded">
               <div className="flex items-center space-x-3">
                 <button
-                  style={{
-                    backgroundColor: button.backgroundColor,
-                    color: button.color
-                  }}
-                  className="px-4 py-2 rounded font-medium"
+                  style={{ '--btn-bg': button.backgroundColor, '--btn-color': button.color }}
+                  className="px-4 py-2 rounded font-medium bg-[var(--btn-bg)] text-[var(--btn-color)]"
                   disabled
                 >
                   {button.text}
@@ -366,12 +363,12 @@ export function Settings({ gameSettings, texts, onUpdateSettings, onUpdateTexts 
         </div>
       </div>
 
-      <div className="bg-white p-6 rounded-lg shadow border">
+      <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow border">
         <div className="flex justify-between items-center mb-4">
           <h4 className="text-lg font-semibold">Page Félicitations - Boutons d'actions</h4>
           <button
             onClick={() => setEditingButtons(true)}
-            className="bg-purple-500 text-white px-4 py-2 rounded hover:bg-purple-600 transition-colors"
+            className="btn-primary"
           >
             Gérer les boutons félicitations
           </button>
@@ -388,11 +385,8 @@ export function Settings({ gameSettings, texts, onUpdateSettings, onUpdateTexts 
             <div key={button.id} className="flex items-center justify-between p-3 bg-gray-50 rounded">
               <div className="flex items-center space-x-3">
                 <button
-                  style={{
-                    backgroundColor: button.backgroundColor,
-                    color: button.color
-                  }}
-                  className="px-4 py-2 rounded font-medium"
+                  style={{ '--btn-bg': button.backgroundColor, '--btn-color': button.color }}
+                  className="px-4 py-2 rounded font-medium bg-[var(--btn-bg)] text-[var(--btn-color)]"
                   disabled
                 >
                   {button.text}
@@ -417,12 +411,12 @@ export function Settings({ gameSettings, texts, onUpdateSettings, onUpdateTexts 
           ))}
         </div>
       </div>
-      <div className="bg-white p-6 rounded-lg shadow border">
+      <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow border">
         <div className="flex justify-between items-center mb-4">
           <h4 className="text-lg font-semibold">Textes de l'application</h4>
           <button
             onClick={() => setEditingTexts(true)}
-            className="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600 transition-colors"
+            className="btn-primary"
           >
             Modifier les textes
           </button>
@@ -431,12 +425,12 @@ export function Settings({ gameSettings, texts, onUpdateSettings, onUpdateTexts 
         <div className="grid gap-4 md:grid-cols-2">
           <div>
             <span className="font-medium">Titre de la page de jeu:</span>
-            <p 
-              className="text-gray-600"
-              style={{ 
-                fontFamily: texts.titleFont,
-                fontSize: `${texts.titleSize}px`,
-                color: texts.titleColor
+            <p
+              className="text-gray-600 font-[var(--title-font)] text-[length:var(--title-size)] text-[var(--title-color)]"
+              style={{
+                '--title-font': texts.titleFont,
+                '--title-size': `${texts.titleSize}px`,
+                '--title-color': texts.titleColor
               }}
             >
               {texts.title}
@@ -444,12 +438,12 @@ export function Settings({ gameSettings, texts, onUpdateSettings, onUpdateTexts 
           </div>
           <div>
             <span className="font-medium">Sous-titre:</span>
-            <p 
-              className="text-gray-600"
-              style={{ 
-                fontFamily: texts.subtitleFont,
-                fontSize: `${texts.subtitleSize}px`,
-                color: texts.subtitleColor
+            <p
+              className="text-gray-600 font-[var(--subtitle-font)] text-[length:var(--subtitle-size)] text-[var(--subtitle-color)]"
+              style={{
+                '--subtitle-font': texts.subtitleFont,
+                '--subtitle-size': `${texts.subtitleSize}px`,
+                '--subtitle-color': texts.subtitleColor
               }}
             >
               {texts.subtitle}
@@ -457,12 +451,12 @@ export function Settings({ gameSettings, texts, onUpdateSettings, onUpdateTexts 
           </div>
           <div>
             <span className="font-medium">Bouton tourner:</span>
-            <p 
-              className="text-gray-600"
-              style={{ 
-                fontFamily: texts.spinButtonFont,
-                fontSize: `${texts.spinButtonSize}px`,
-                color: texts.spinButtonColor
+            <p
+              className="text-gray-600 font-[var(--spin-font)] text-[length:var(--spin-size)] text-[var(--spin-color)]"
+              style={{
+                '--spin-font': texts.spinButtonFont,
+                '--spin-size': `${texts.spinButtonSize}px`,
+                '--spin-color': texts.spinButtonColor
               }}
             >
               {texts.spinButton}
@@ -470,12 +464,12 @@ export function Settings({ gameSettings, texts, onUpdateSettings, onUpdateTexts 
           </div>
           <div>
             <span className="font-medium">Félicitations:</span>
-            <p 
-              className="text-gray-600"
-              style={{ 
-                fontFamily: texts.congratulationsFont,
-                fontSize: `${texts.congratulationsSize}px`,
-                color: texts.congratulationsColor
+            <p
+              className="text-gray-600 font-[var(--congrats-font)] text-[length:var(--congrats-size)] text-[var(--congrats-color)]"
+              style={{
+                '--congrats-font': texts.congratulationsFont,
+                '--congrats-size': `${texts.congratulationsSize}px`,
+                '--congrats-color': texts.congratulationsColor
               }}
             >
               {texts.congratulations}
@@ -486,7 +480,7 @@ export function Settings({ gameSettings, texts, onUpdateSettings, onUpdateTexts 
 
       {editingTexts && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
-          <div className="bg-white rounded-lg p-6 w-full max-w-4xl max-h-[90vh] overflow-y-auto">
+          <div className="bg-white dark:bg-gray-800 rounded-lg p-6 w-full max-w-4xl max-h-[90vh] overflow-y-auto">
             <h4 className="text-lg font-semibold mb-4">Modifier les textes</h4>
             
             <div className="space-y-4">
@@ -711,7 +705,7 @@ export function Settings({ gameSettings, texts, onUpdateSettings, onUpdateTexts 
 
       {editingLegal && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
-          <div className="bg-white rounded-lg p-6 w-full max-w-4xl max-h-[90vh] overflow-y-auto">
+          <div className="bg-white dark:bg-gray-800 rounded-lg p-6 w-full max-w-4xl max-h-[90vh] overflow-y-auto">
             <h4 className="text-lg font-semibold mb-4">Modifier les mentions légales</h4>
             
             <div className="space-y-4">
@@ -767,7 +761,7 @@ export function Settings({ gameSettings, texts, onUpdateSettings, onUpdateTexts 
 
       {editingRules && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
-          <div className="bg-white rounded-lg p-6 w-full max-w-4xl max-h-[90vh] overflow-y-auto">
+          <div className="bg-white dark:bg-gray-800 rounded-lg p-6 w-full max-w-4xl max-h-[90vh] overflow-y-auto">
             <h4 className="text-lg font-semibold mb-4">Modifier les règles du jeu</h4>
             
             <div className="space-y-4">
@@ -823,7 +817,7 @@ export function Settings({ gameSettings, texts, onUpdateSettings, onUpdateTexts 
 
       {editingButtons && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
-          <div className="bg-white rounded-lg p-6 w-full max-w-4xl max-h-[90vh] overflow-y-auto">
+          <div className="bg-white dark:bg-gray-800 rounded-lg p-6 w-full max-w-4xl max-h-[90vh] overflow-y-auto">
             <div className="flex justify-between items-center mb-4">
               <h4 className="text-lg font-semibold">Gérer les boutons d'actions - Page Félicitations</h4>
               <button
@@ -940,11 +934,8 @@ export function Settings({ gameSettings, texts, onUpdateSettings, onUpdateTexts 
                     <div className="flex items-center justify-between">
                       <span className="text-sm font-medium text-gray-700">Aperçu du bouton :</span>
                       <button
-                        style={{
-                          backgroundColor: button.backgroundColor,
-                          color: button.color
-                        }}
-                        className="px-4 py-2 rounded font-medium shadow-sm"
+                        style={{ '--btn-bg': button.backgroundColor, '--btn-color': button.color }}
+                        className="px-4 py-2 rounded font-medium shadow-sm bg-[var(--btn-bg)] text-[var(--btn-color)]"
                         disabled
                       >
                         {button.text}

--- a/src/components/Admin/Statistics.tsx
+++ b/src/components/Admin/Statistics.tsx
@@ -273,7 +273,7 @@ export function Statistics({ stats, onReset, onExport }: StatisticsProps) {
 
       {/* Statistiques du jour */}
       <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
-        <div className="bg-white p-6 rounded-lg shadow border">
+        <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow border">
           <div className="text-2xl font-bold text-blue-600">{stats.totalSpins}</div>
           <div className="text-gray-600">Spins totaux</div>
           <div className="text-sm text-gray-500 mt-1">
@@ -281,7 +281,7 @@ export function Statistics({ stats, onReset, onExport }: StatisticsProps) {
           </div>
         </div>
         
-        <div className="bg-white p-6 rounded-lg shadow border">
+        <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow border">
           <div className="text-2xl font-bold text-green-600">{stats.dailySpins}</div>
           <div className="text-gray-600">Spins aujourd'hui</div>
           <div className="text-sm text-gray-500 mt-1">
@@ -289,7 +289,7 @@ export function Statistics({ stats, onReset, onExport }: StatisticsProps) {
           </div>
         </div>
         
-        <div className="bg-white p-6 rounded-lg shadow border">
+        <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow border">
           <div className="text-2xl font-bold text-purple-600">{stats.reviewClicks}</div>
           <div className="text-gray-600">Clics avis Google</div>
           <div className="text-sm text-gray-500 mt-1">
@@ -297,7 +297,7 @@ export function Statistics({ stats, onReset, onExport }: StatisticsProps) {
           </div>
         </div>
         
-        <div className="bg-white p-6 rounded-lg shadow border">
+        <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow border">
           <div className="text-2xl font-bold text-orange-600">
             {todayStats?.conversionRate || 0}%
           </div>
@@ -309,7 +309,7 @@ export function Statistics({ stats, onReset, onExport }: StatisticsProps) {
       </div>
 
       {/* Contrôles du graphique */}
-      <div className="bg-white p-4 rounded-lg shadow border">
+      <div className="bg-white dark:bg-gray-800 p-4 rounded-lg shadow border">
         <div className="flex flex-wrap items-center justify-between gap-4">
           <div className="flex items-center space-x-4">
             <div className="flex items-center space-x-2">
@@ -370,7 +370,7 @@ export function Statistics({ stats, onReset, onExport }: StatisticsProps) {
       </div>
 
       {/* Graphique principal */}
-      <div className="bg-white p-6 rounded-lg shadow border">
+      <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow border">
         <div className="h-96">
           {chartType === 'line' ? (
             <Line data={chartData} options={chartOptions} />
@@ -381,7 +381,7 @@ export function Statistics({ stats, onReset, onExport }: StatisticsProps) {
       </div>
 
       {/* Distribution des gains */}
-      <div className="bg-white p-6 rounded-lg shadow border">
+      <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow border">
         <h4 className="text-lg font-semibold mb-4">Distribution des gains</h4>
         {Object.keys(stats.prizeDistribution).length === 0 ? (
           <p className="text-gray-500">Aucune donnée disponible</p>
@@ -392,11 +392,9 @@ export function Statistics({ stats, onReset, onExport }: StatisticsProps) {
                 <span className="text-gray-700">{prize}</span>
                 <div className="flex items-center space-x-3">
                   <div className="bg-gray-200 rounded-full h-2 w-32">
-                    <div 
-                      className="bg-blue-500 h-2 rounded-full"
-                      style={{ 
-                        width: `${stats.totalSpins > 0 ? (count / stats.totalSpins) * 100 : 0}%` 
-                      }}
+                    <div
+                      style={{ '--progress': `${stats.totalSpins > 0 ? (count / stats.totalSpins) * 100 : 0}%` }}
+                      className="bg-blue-500 h-2 rounded-full w-[var(--progress)]"
                     />
                   </div>
                   <span className="text-sm text-gray-600 w-12 text-right">
@@ -410,7 +408,7 @@ export function Statistics({ stats, onReset, onExport }: StatisticsProps) {
       </div>
 
       {/* Informations */}
-      <div className="bg-white p-6 rounded-lg shadow border">
+      <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow border">
         <h4 className="text-lg font-semibold mb-2">Informations</h4>
         <div className="text-sm text-gray-600 space-y-1">
           <p>Dernière remise à zéro: {new Date(stats.lastReset).toLocaleDateString('fr-FR')}</p>

--- a/src/components/Admin/ThemeManagement.tsx
+++ b/src/components/Admin/ThemeManagement.tsx
@@ -45,7 +45,7 @@ export function ThemeManagement({ themes, activeTheme, onUpdateThemes, onSetActi
         <h3 className="text-xl font-bold">Gestion des Thèmes</h3>
         <button
           onClick={handleAddTheme}
-          className="bg-green-500 text-white px-4 py-2 rounded hover:bg-green-600 transition-colors"
+          className="btn-primary"
         >
           Nouveau thème
         </button>
@@ -66,7 +66,7 @@ export function ThemeManagement({ themes, activeTheme, onUpdateThemes, onSetActi
 
       <div className="grid gap-4 md:grid-cols-2">
         {themes.map((theme) => (
-          <div key={theme.id} className="bg-white border border-gray-200 rounded-lg p-4">
+          <div key={theme.id} className="bg-white dark:bg-gray-800 border border-gray-200 rounded-lg p-4">
             <div className="flex justify-between items-start mb-4">
               <div>
                 <h4 className="font-semibold text-lg">{theme.name}</h4>
@@ -97,25 +97,25 @@ export function ThemeManagement({ themes, activeTheme, onUpdateThemes, onSetActi
             
             <div className="space-y-2">
               <div className="flex items-center space-x-2">
-                <div 
-                  className="w-6 h-6 rounded border"
-                  style={{ backgroundColor: theme.primaryColor }}
+                <div
+                  style={{ '--color': theme.primaryColor }}
+                  className="w-6 h-6 rounded border bg-[var(--color)]"
                 />
                 <span className="text-sm">Primaire: {theme.primaryColor}</span>
               </div>
               
               <div className="flex items-center space-x-2">
-                <div 
-                  className="w-6 h-6 rounded border"
-                  style={{ backgroundColor: theme.secondaryColor }}
+                <div
+                  style={{ '--color': theme.secondaryColor }}
+                  className="w-6 h-6 rounded border bg-[var(--color)]"
                 />
                 <span className="text-sm">Secondaire: {theme.secondaryColor}</span>
               </div>
               
               <div className="flex items-center space-x-2">
-                <div 
-                  className="w-6 h-6 rounded border"
-                  style={{ backgroundColor: theme.accentColor }}
+                <div
+                  style={{ '--color': theme.accentColor }}
+                  className="w-6 h-6 rounded border bg-[var(--color)]"
                 />
                 <span className="text-sm">Accent: {theme.accentColor}</span>
               </div>
@@ -126,7 +126,7 @@ export function ThemeManagement({ themes, activeTheme, onUpdateThemes, onSetActi
 
       {editingTheme && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
-          <div className="bg-white rounded-lg p-6 w-full max-w-md max-h-96 overflow-y-auto">
+          <div className="bg-white dark:bg-gray-800 rounded-lg p-6 w-full max-w-md max-h-96 overflow-y-auto">
             <h4 className="text-lg font-semibold mb-4">Modifier le thème</h4>
             
             <div className="space-y-4">

--- a/src/components/PrizeModal.tsx
+++ b/src/components/PrizeModal.tsx
@@ -61,12 +61,12 @@ export function PrizeModal({ prize, texts, gameSettings, onClose, onReviewClick 
   };
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
-      <div className="bg-white rounded-2xl max-w-md w-full p-6 text-center">
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50 animate-fadeIn">
+      <div className="bg-white dark:bg-gray-800 rounded-2xl max-w-md w-full p-6 text-center">
         <div className="mb-6">
-          <div 
-            className="w-24 h-24 mx-auto rounded-full flex items-center justify-center text-4xl mb-4"
-            style={{ backgroundColor: prize.color }}
+          <div
+            style={{ '--prize-color': prize.color }}
+            className="w-24 h-24 mx-auto rounded-full flex items-center justify-center text-4xl mb-4 bg-[var(--prize-color)]"
           >
             {prize.icon}
           </div>
@@ -74,13 +74,13 @@ export function PrizeModal({ prize, texts, gameSettings, onClose, onReviewClick 
           <h2 className="text-2xl font-bold text-gray-800 mb-2">
           </h2>
           
-          <h2 
-            className="font-bold mb-2"
+          <h2
             style={{
-              fontFamily: texts.congratulationsFont,
-              fontSize: `${texts.congratulationsSize}px`,
-              color: texts.congratulationsColor
+              '--congrats-font': texts.congratulationsFont,
+              '--congrats-size': `${texts.congratulationsSize}px`,
+              '--congrats-color': texts.congratulationsColor
             }}
+            className="font-bold mb-2 font-[var(--congrats-font)] text-[length:var(--congrats-size)] text-[var(--congrats-color)]"
           >
             {texts.congratulations}
           </h2>
@@ -109,12 +109,12 @@ export function PrizeModal({ prize, texts, gameSettings, onClose, onReviewClick 
                 }
               }}
               style={{
-                backgroundColor: button.backgroundColor,
-                color: button.color
+                '--btn-bg': button.backgroundColor,
+                '--btn-color': button.color
               }}
-              className={`w-full rounded-xl font-semibold transition-colors hover:opacity-90 ${
-                button.id === 'google-review' 
-                  ? 'py-4 flex flex-col items-center justify-center space-y-2' 
+              className={`w-full rounded-xl font-semibold transition-colors hover:opacity-90 bg-[var(--btn-bg)] text-[var(--btn-color)] ${
+                button.id === 'google-review'
+                  ? 'py-4 flex flex-col items-center justify-center space-y-2'
                   : 'py-3'
               }`}
             >

--- a/src/components/Wheel.tsx
+++ b/src/components/Wheel.tsx
@@ -100,22 +100,23 @@ export function Wheel({ prizes, texts, gameSettings, onResult, onStatsUpdate }: 
   return (
     <div className="flex flex-col items-center space-y-8 p-6">
       <div className="text-center space-y-2">
-        <h1 
-          className="font-bold forest-title"
+        <h1
           style={{
-            fontFamily: texts.titleFont,
-            fontSize: `${texts.titleSize}px`,
-            color: texts.titleColor
+            '--title-font': texts.titleFont,
+            '--title-size': `${texts.titleSize}px`,
+            '--title-color': texts.titleColor
           }}
+          className="font-bold forest-title font-[var(--title-font)] text-[length:var(--title-size)] text-[var(--title-color)]"
         >
           {texts.title}
         </h1>
-        <p 
+        <p
           style={{
-            fontFamily: texts.subtitleFont,
-            fontSize: `${texts.subtitleSize}px`,
-            color: texts.subtitleColor
+            '--subtitle-font': texts.subtitleFont,
+            '--subtitle-size': `${texts.subtitleSize}px`,
+            '--subtitle-color': texts.subtitleColor
           }}
+          className="font-[var(--subtitle-font)] text-[length:var(--subtitle-size)] text-[var(--subtitle-color)]"
         >
           {texts.subtitle}
         </p>
@@ -140,12 +141,13 @@ export function Wheel({ prizes, texts, gameSettings, onResult, onStatsUpdate }: 
           onClick={handleSpin}
           disabled={isSpinning || !canPlay}
           style={{
-            fontFamily: texts.spinButtonFont,
-            fontSize: `${texts.spinButtonSize}px`,
-            color: texts.spinButtonColor
+            '--spin-font': texts.spinButtonFont,
+            '--spin-size': `${texts.spinButtonSize}px`,
+            '--spin-color': texts.spinButtonColor
           }}
           className={`
             px-8 py-4 rounded-full font-bold transition-all duration-200
+            font-[var(--spin-font)] text-[length:var(--spin-size)] text-[var(--spin-color)]
             ${isSpinning || !canPlay
               ? 'bg-gray-400 text-gray-600 cursor-not-allowed'
               : 'bg-gradient-to-r from-blue-500 to-purple-600 text-white hover:from-blue-600 hover:to-purple-700 transform hover:scale-105 active:scale-95'
@@ -163,10 +165,10 @@ export function Wheel({ prizes, texts, gameSettings, onResult, onStatsUpdate }: 
                 key={button.id}
                 onClick={() => handleActionButtonClick(button.url)}
                 style={{
-                  backgroundColor: button.backgroundColor,
-                  color: button.color
+                  '--btn-bg': button.backgroundColor,
+                  '--btn-color': button.color
                 }}
-                className="px-4 py-2 rounded-full font-medium transition-colors hover:opacity-90"
+                className="px-4 py-2 rounded-full font-medium transition-colors hover:opacity-90 bg-[var(--btn-bg)] text-[var(--btn-color)]"
               >
                 {button.text}
               </button>

--- a/src/components/WheelCanvas.tsx
+++ b/src/components/WheelCanvas.tsx
@@ -122,21 +122,21 @@ export function WheelCanvas({ prizes, rotation, size }: WheelCanvasProps) {
         ref={canvasRef}
         width={size}
         height={size}
-        style={{ 
-          transform: `rotate(${rotation}deg)`,
-          transition: rotation > 0 ? 'transform 3.5s cubic-bezier(0.17, 0.67, 0.12, 0.99)' : 'none'
-        }}
-        className="drop-shadow-lg"
+        style={{ '--rotation': `${rotation}deg` }}
+        className={`drop-shadow-lg [transform:rotate(var(--rotation))] ${
+          rotation > 0
+            ? 'transition-transform duration-[3500ms] [transition-timing-function:cubic-bezier(0.17,0.67,0.12,0.99)]'
+            : ''
+        }`}
       />
       
       {/* Pointeur en haut */}
       <div className="absolute top-0 left-1/2 transform -translate-x-1/2 -translate-y-3 z-10">
         <div className="flex flex-col items-center">
-          <div 
-            className="w-0 h-0 border-l-[15px] border-r-[15px] border-t-[25px] border-transparent border-t-red-600"
-            style={{ filter: 'drop-shadow(0 3px 6px rgba(0,0,0,0.7))' }}
+          <div
+            className="w-0 h-0 border-l-[15px] border-r-[15px] border-t-[25px] border-transparent border-t-red-600 drop-shadow-[0_3px_6px_rgba(0,0,0,0.7)]"
           />
-          <div className="w-0.5 h-3 bg-red-600 mt-0.5" style={{ filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.5))' }}></div>
+          <div className="w-0.5 h-3 bg-red-600 mt-0.5 drop-shadow-[0_1px_2px_rgba(0,0,0,0.5)]"></div>
         </div>
       </div>
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -2,10 +2,34 @@
 @tailwind components;
 @tailwind utilities;
 
-.forest-title {
-  font-family: 'Fredoka', cursive;
-  font-weight: 700;
-  color: #1F2937;
-  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
-  letter-spacing: 0.5px;
+@layer base {
+  :root {
+    --primary-color: #2563eb;
+    --secondary-color: #4b5563;
+    --accent-color: #10b981;
+    --bg-color: #f9fafb;
+    --text-color: #1f2937;
+  }
+
+  .dark {
+    --primary-color: #3b82f6;
+    --secondary-color: #9ca3af;
+    --accent-color: #34d399;
+    --bg-color: #1f2937;
+    --text-color: #f3f4f6;
+  }
+
+  .forest-title {
+    font-family: 'Fredoka', cursive;
+    font-weight: 700;
+    color: #1f2937;
+    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
+    letter-spacing: 0.5px;
+  }
+}
+
+@layer components {
+  .btn-primary {
+    @apply bg-primary text-white px-4 py-2 rounded-full font-semibold transition-colors duration-200 hover:bg-accent;
+  }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,26 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        primary: 'var(--primary-color)',
+        secondary: 'var(--secondary-color)',
+        accent: 'var(--accent-color)',
+        background: 'var(--bg-color)',
+        text: 'var(--text-color)'
+      },
+      keyframes: {
+        fadeIn: {
+          from: { opacity: '0' },
+          to: { opacity: '1' }
+        }
+      },
+      animation: {
+        fadeIn: 'fadeIn 0.3s ease-in-out'
+      }
+    }
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- define CSS variable-based theme palette with dark mode and reusable button component
- replace inline styles in Wheel, PrizeModal, and admin panels with Tailwind classes
- unify admin and game interfaces with new theme classes and dark mode support

## Testing
- `npm run lint` (fails: multiple existing lint errors)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bab9f85ea4832997fb8c8c09781639