### PR TITLE
feat: add configuration context and broadcast sync

### DIFF
--- a/src/components/Wheel.tsx
+++ b/src/components/Wheel.tsx
@@ -1,74 +1,37 @@
 import React, { useState, useEffect } from 'react';
 import { WheelCanvas } from './WheelCanvas';
 import { useWheel } from '../hooks/useWheel';
-import { Prize, AppTexts, GameSettings } from '../types';
 import { AntiCheatSystem } from '../utils/antiCheat';
+import { useConfig } from '../context/ConfigContext';
 
 interface WheelProps {
-  prizes: Prize[];
-  texts: AppTexts;
-  gameSettings: GameSettings;
   onResult: (prizeId: string) => void;
   onStatsUpdate: (type: 'spin' | 'review') => void;
 }
 
 const antiCheat = new AntiCheatSystem();
 
-export function Wheel({ prizes, texts, gameSettings, onResult, onStatsUpdate }: WheelProps) {
+export function Wheel({ onResult, onStatsUpdate }: WheelProps) {
+  const { config } = useConfig();
+  const { prizes, texts, gameSettings } = config;
   const { isSpinning, rotation, spin } = useWheel(prizes);
   const [message, setMessage] = useState<string>('');
   const [canPlay, setCanPlay] = useState(true);
-  const [configVersion, setConfigVersion] = useState(0);
 
-  // Surveiller les changements de configuration
   useEffect(() => {
-    const checkConfigUpdates = () => {
-      console.log('🎯 Wheel: Checking config updates');
-      setConfigVersion(prev => prev + 1);
-      
-      // Vérifier si on peut encore jouer après une mise à jour
-      const playCheck = antiCheat.canPlay(gameSettings.playLimit);
-      if (!playCheck.allowed && playCheck.reason) {
-        setMessage(playCheck.reason);
-        setCanPlay(false);
-      } else if (playCheck.allowed && !canPlay && !message.includes('erreur')) {
-        setMessage('');
-        setCanPlay(true);
-      }
-    };
-
-    const handleStorageChange = (e: StorageEvent) => {
-      if (e.key === 'config_update_trigger' || e.key === 'last_config_update' || e.key === 'force_reload_trigger') {
-        console.log('🎯 Wheel: Storage change detected');
-        checkConfigUpdates();
-      }
-    };
-
-    const handleConfigChanged = () => {
-      console.log('🎯 Wheel: Config changed event');
-      checkConfigUpdates();
-    };
-
-    window.addEventListener('configUpdated', checkConfigUpdates);
-    window.addEventListener('forceConfigReload', checkConfigUpdates);
-    window.addEventListener('configChanged', handleConfigChanged);
-    window.addEventListener('storage', handleStorageChange);
-    window.addEventListener('focus', checkConfigUpdates);
-    window.addEventListener('visibilitychange', checkConfigUpdates);
-    
-    return () => {
-      window.removeEventListener('configUpdated', checkConfigUpdates);
-      window.removeEventListener('forceConfigReload', checkConfigUpdates);
-      window.removeEventListener('configChanged', handleConfigChanged);
-      window.removeEventListener('storage', handleStorageChange);
-      window.removeEventListener('focus', checkConfigUpdates);
-      window.removeEventListener('visibilitychange', checkConfigUpdates);
-    };
-  }, [gameSettings.playLimit, canPlay, message]);
+    const playCheck = antiCheat.canPlay(gameSettings.playLimit);
+    if (!playCheck.allowed && playCheck.reason) {
+      setMessage(playCheck.reason);
+      setCanPlay(false);
+    } else if (playCheck.allowed) {
+      setMessage('');
+      setCanPlay(true);
+    }
+  }, [gameSettings.playLimit]);
 
   const handleSpin = async () => {
     const playCheck = antiCheat.canPlay(gameSettings.playLimit);
-    
+
     if (!playCheck.allowed) {
       setMessage(playCheck.reason || texts.alreadyPlayed);
       setCanPlay(false);
@@ -81,15 +44,9 @@ export function Wheel({ prizes, texts, gameSettings, onResult, onStatsUpdate }: 
       onResult(result.prizeId);
       onStatsUpdate('spin');
       setCanPlay(false);
-    } catch (error) {
+    } catch {
       setMessage('Une erreur est survenue. Veuillez réessayer.');
     }
-  };
-
-  const handleReviewClick = () => {
-    console.log('🎯 Wheel - handleReviewClick - URL utilisée:', gameSettings.googleReviewUrl);
-    onStatsUpdate('review');
-    window.open(gameSettings.googleReviewUrl, '_blank');
   };
 
   const handleActionButtonClick = (url: string) => {
@@ -100,7 +57,7 @@ export function Wheel({ prizes, texts, gameSettings, onResult, onStatsUpdate }: 
   return (
     <div className="flex flex-col items-center space-y-8 p-6">
       <div className="text-center space-y-2">
-        <h1 
+        <h1
           className="font-bold forest-title"
           style={{
             fontFamily: texts.titleFont,
@@ -110,7 +67,7 @@ export function Wheel({ prizes, texts, gameSettings, onResult, onStatsUpdate }: 
         >
           {texts.title}
         </h1>
-        <p 
+        <p
           style={{
             fontFamily: texts.subtitleFont,
             fontSize: `${texts.subtitleSize}px`,
@@ -122,11 +79,7 @@ export function Wheel({ prizes, texts, gameSettings, onResult, onStatsUpdate }: 
       </div>
 
       <div className="relative">
-        <WheelCanvas 
-          prizes={prizes}
-          rotation={rotation}
-          size={300}
-        />
+        <WheelCanvas prizes={prizes} rotation={rotation} size={300} />
       </div>
 
       {message && (
@@ -144,13 +97,11 @@ export function Wheel({ prizes, texts, gameSettings, onResult, onStatsUpdate }: 
             fontSize: `${texts.spinButtonSize}px`,
             color: texts.spinButtonColor
           }}
-          className={`
-            px-8 py-4 rounded-full font-bold transition-all duration-200
-            ${isSpinning || !canPlay
+          className={`px-8 py-4 rounded-full font-bold transition-all duration-200 ${
+            isSpinning || !canPlay
               ? 'bg-gray-400 text-gray-600 cursor-not-allowed'
               : 'bg-gradient-to-r from-blue-500 to-purple-600 text-white hover:from-blue-600 hover:to-purple-700 transform hover:scale-105 active:scale-95'
-            }
-          `}
+          }`}
         >
           {isSpinning ? '🎯 En cours...' : texts.spinButton}
         </button>
@@ -158,22 +109,25 @@ export function Wheel({ prizes, texts, gameSettings, onResult, onStatsUpdate }: 
         {/* Boutons d'actions personnalisés */}
         {texts.actionButtons.filter(btn => btn.isActive && btn.id !== 'google-review').length > 0 && (
           <div className="flex flex-wrap justify-center gap-3">
-            {texts.actionButtons.filter(btn => btn.isActive && btn.id !== 'google-review').map(button => (
-              <button
-                key={button.id}
-                onClick={() => handleActionButtonClick(button.url)}
-                style={{
-                  backgroundColor: button.backgroundColor,
-                  color: button.color
-                }}
-                className="px-4 py-2 rounded-full font-medium transition-colors hover:opacity-90"
-              >
-                {button.text}
-              </button>
-            ))}
+            {texts.actionButtons
+              .filter(btn => btn.isActive && btn.id !== 'google-review')
+              .map(button => (
+                <button
+                  key={button.id}
+                  onClick={() => handleActionButtonClick(button.url)}
+                  style={{
+                    backgroundColor: button.backgroundColor,
+                    color: button.color
+                  }}
+                  className="px-4 py-2 rounded-full font-medium transition-colors hover:opacity-90"
+                >
+                  {button.text}
+                </button>
+              ))}
           </div>
         )}
       </div>
     </div>
   );
 }
+

--- a/src/context/ConfigContext.tsx
+++ b/src/context/ConfigContext.tsx
@@ -1,0 +1,55 @@
+import React, { createContext, useContext, useEffect, useRef, useState } from 'react';
+import { AppConfig } from '../types';
+import { getStoredConfig, saveConfig } from '../utils/config';
+
+interface ConfigContextValue {
+  config: AppConfig;
+  updateConfig: (config: AppConfig | ((prev: AppConfig) => AppConfig)) => void;
+  reloadConfig: () => void;
+}
+
+const ConfigContext = createContext<ConfigContextValue | undefined>(undefined);
+
+export const ConfigProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [config, setConfig] = useState<AppConfig>(() => getStoredConfig());
+  const channelRef = useRef<BroadcastChannel | null>(null);
+
+  useEffect(() => {
+    const channel = new BroadcastChannel('config_channel');
+    channel.onmessage = (event: MessageEvent) => {
+      if (event.data?.type === 'configUpdated') {
+        setConfig(event.data.payload as AppConfig);
+      }
+    };
+    channelRef.current = channel;
+    return () => channel.close();
+  }, []);
+
+  const updateConfig = (value: AppConfig | ((prev: AppConfig) => AppConfig)) => {
+    setConfig(prev => {
+      const next = typeof value === 'function' ? (value as (p: AppConfig) => AppConfig)(prev) : value;
+      saveConfig(next);
+      channelRef.current?.postMessage({ type: 'configUpdated', payload: next });
+      return next;
+    });
+  };
+
+  const reloadConfig = () => {
+    setConfig(getStoredConfig());
+  };
+
+  return (
+    <ConfigContext.Provider value={{ config, updateConfig, reloadConfig }}>
+      {children}
+    </ConfigContext.Provider>
+  );
+};
+
+export const useConfig = () => {
+  const context = useContext(ConfigContext);
+  if (!context) {
+    throw new Error('useConfig must be used within a ConfigProvider');
+  }
+  return context;
+};
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
+import { ConfigProvider } from './context/ConfigContext';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <ConfigProvider>
+      <App />
+    </ConfigProvider>
   </StrictMode>
 );


### PR DESCRIPTION
## Summary
- add ConfigContext with BroadcastChannel-based sync
- consume configuration via context in App and Wheel
- wrap App with ConfigProvider

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: existing lint errors in unrelated files)*
- `npx eslint src/App.tsx src/components/Wheel.tsx src/context/ConfigContext.tsx src/main.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bab9f3106883298c7386dbb28b4d29