### PR TITLE
Fix AntiCheat canPlay overload signature

### DIFF
--- a/src/utils/antiCheat.ts
+++ b/src/utils/antiCheat.ts
@@ -28,8 +28,7 @@ export class AntiCheatSystem {
     return deviceId;
   }
   
-  canPlay(playLimit: 'once' | 'daily'): { allowed: boolean; reason?: string } {
-  }
+  canPlay(playLimit: 'once' | 'daily'): { allowed: boolean; reason?: string };
   canPlay(playLimit: 'once' | 'daily' | 'unlimited'): { allowed: boolean; reason?: string } {
     if (playLimit === 'unlimited') {
       return { allowed: true };


### PR DESCRIPTION
## Summary
- Correct `canPlay` overload in `AntiCheatSystem` to support unlimited play and remove empty stub

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 32 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bab9e3db8c832983e17a1e1a0ff675