### PR TITLE
fix: rename forcSync to forceSync

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,7 +62,7 @@ function App() {
 
     const handleCloudSync = () => {
       console.log('☁️ Cloud sync triggered');
-      cloudSync.forcSync();
+      cloudSync.forceSync();
     };
 
     const handleConfigChanged = (e: CustomEvent) => {

--- a/src/utils/cloudSync.ts
+++ b/src/utils/cloudSync.ts
@@ -152,7 +152,7 @@ export class CloudSyncManager {
   }
 
   // Méthode pour forcer une synchronisation
-  async forcSync(): Promise<void> {
+  async forceSync(): Promise<void> {
     console.log('🔄 Synchronisation forcée...');
     await this.syncFromCloud();
   }


### PR DESCRIPTION
## Summary
- rename misspelled forcSync to forceSync in cloudSync manager
- update app to call new method name

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bab9ddd33c832985abb82ad066a8f5